### PR TITLE
Add mocked starknet transaction type for client node interaction

### DIFF
--- a/sequencer/node/Cargo.toml
+++ b/sequencer/node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+cairo-felt = "0.5.2"
 tokio = { version = "1.1.0", features = ["time", "macros", "net", "rt-multi-thread"] }
 tokio-util = { version = "0.7.3", features = ["codec"] }
 log = "0.4.0"

--- a/sequencer/node/src/client.rs
+++ b/sequencer/node/src/client.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use bytes::BufMut as _;
 use bytes::BytesMut;
+use cairo_felt::Felt252;
 use clap::Parser;
 use env_logger::Env;
 use futures::future::join_all;
@@ -8,6 +9,10 @@ use futures::sink::SinkExt as _;
 use log::{info, warn};
 use mempool::TransactionType;
 use rand::Rng;
+use rpc_endpoint::rpc::types::Transaction::Invoke;
+use rpc_endpoint::rpc::InvokeTransaction::{self, V1};
+use rpc_endpoint::rpc::InvokeTransactionV1;
+use rpc_endpoint::rpc::Transaction;
 use std::net::SocketAddr;
 use tokio::net::TcpStream;
 use tokio::time::{interval, sleep, Duration, Instant};
@@ -113,8 +118,19 @@ impl Client {
                     tx.put_u8(0u8); // Sample txs start with 0.
                     tx.put_u64(counter); // This counter identifies the tx.
 
-                    let transaction_type = TransactionType::ExecuteFibonacci(200 + counter);
-                    let bytes = bincode::serialize(&transaction_type).unwrap();
+                    // let transaction_type = TransactionType::ExecuteFibonacci(200 + counter);
+                    let starknet_transaction = InvokeTransactionV1 {
+                        transaction_hash: Felt252::new(1920310231),
+                        max_fee: Felt252::new(89853483),
+                        signature: vec![Felt252::new(183728913)],
+                        nonce: Felt252::new(762716321),
+                        sender_address: Felt252::new(91232018),
+                        calldata: vec![Felt252::new(8126371)],
+                    };
+
+                    let starknet_transaction_str =
+                        serde_json::to_string(&starknet_transaction).unwrap();
+                    let bytes = starknet_transaction_str.as_bytes().to_owned();
                     for b in bytes {
                         tx.put_u8(b);
                     }
@@ -123,13 +139,28 @@ impl Client {
 
                     tx.put_u8(1u8); // Standard txs start with 1.
                     tx.put_u64(r); // Ensures all clients send different txs.
-                    let transaction_type = TransactionType::ExecuteFibonacci(200);
-                    let bytes = bincode::serialize(&transaction_type).unwrap();
+
+                    let starknet_transaction = InvokeTransactionV1 {
+                        transaction_hash: Felt252::new(1920310231),
+                        max_fee: Felt252::new(89853483),
+                        signature: vec![Felt252::new(183728913)],
+                        nonce: Felt252::new(762716321),
+                        sender_address: Felt252::new(91232018),
+                        calldata: vec![Felt252::new(8126371)],
+                    };
+
+                    let starknet_transaction_str =
+                        serde_json::to_string(&starknet_transaction).unwrap();
+                    let bytes = starknet_transaction_str.as_bytes().to_owned();
 
                     for b in bytes {
                         tx.put_u8(b);
                     }
                 };
+                if self.size < tx.len() {
+                    warn!("Transaction size too big");
+                    break 'main;
+                }
                 tx.resize(self.size, 0u8);
                 let bytes = tx.split().freeze();
 


### PR DESCRIPTION
Done:
- Sends from the client a serialized version of a mocked starknet tx
- Receives the tx in the node (needs a fix)
- The nodes execute cairo_native fibonacci for each transaction. The output is logged.

Missing:
- Fix serialization bug in the node
- Write the tx to the external store (needs fix with db in multiple node scenario)