### PR TITLE
Lambdaworks Prover and verifier updated

### DIFF
--- a/watcher_dispatcher/native/watcher_dispatcher/Cargo.lock
+++ b/watcher_dispatcher/native/watcher_dispatcher/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "lambdaworks-stark"
 version = "0.1.0"
-source = "git+https://github.com/lambdaclass/lambdaworks_cairo_prover.git?rev=ebc36fa#ebc36fa0dcd0eecf732560ef5aecf3425403d8f8"
+source = "git+https://github.com/lambdaclass/lambdaworks_cairo_prover.git?rev=d0c5348#d0c5348869fa893b2f0d18b275fa081af605b554"
 dependencies = [
  "bincode 2.0.0-rc.2",
  "cairo-lang-starknet",

--- a/watcher_dispatcher/native/watcher_dispatcher/Cargo.toml
+++ b/watcher_dispatcher/native/watcher_dispatcher/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.29.1"
-lambdaworks-stark = { git = "https://github.com/lambdaclass/lambdaworks_cairo_prover.git", rev = "ebc36fa" }
+lambdaworks-stark = { git = "https://github.com/lambdaclass/lambdaworks_cairo_prover.git", rev = "d0c5348" }
 lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks", rev = "a21d2c5" }

--- a/watcher_dispatcher/native/watcher_dispatcher/README.md
+++ b/watcher_dispatcher/native/watcher_dispatcher/README.md
@@ -18,3 +18,9 @@ end
 ## Examples
 
 [This](https://github.com/rusterlium/NifIo) is a complete example of a NIF written in Rust.
+
+## Important Note
+
+The prover and verifier must agree on proof options.
+By the moment, we are using default proof options meant for testing.
+This SHOULD be changed in the future for production.

--- a/watcher_dispatcher/native/watcher_dispatcher/src/cairo.rs
+++ b/watcher_dispatcher/native/watcher_dispatcher/src/cairo.rs
@@ -1,18 +1,14 @@
 use lambdaworks_math::field::fields::fft_friendly::stark_252_prime_field::Stark252PrimeField;
-use lambdaworks_math::field::traits::IsFFTField;
 use lambdaworks_math::traits::ByteConversion;
 use lambdaworks_math::traits::{Deserializable, Serializable};
+use lambdaworks_stark::cairo::air::generate_cairo_proof;
+use lambdaworks_stark::cairo::air::verify_cairo_proof;
 use lambdaworks_stark::cairo::air::{CairoAIR, PublicInputs};
 use lambdaworks_stark::cairo::runner::run::{generate_prover_args, CairoVersion};
 use lambdaworks_stark::starks::proof::options::ProofOptions;
 use lambdaworks_stark::starks::proof::stark::StarkProof;
 use lambdaworks_stark::starks::{fri::FieldElement, prover::prove, traits::AIR, verifier::verify};
-
-//proof::StarkProof, proof_options::ProofOptions,
-
 use rustler::Binary;
-
-const GRINDING_FACTOR: u8 = 10;
 
 #[rustler::nif]
 /// Loads the program in path, runs it with the Cairo VM, and makes a proof of it
@@ -22,43 +18,28 @@ pub fn run_program_and_get_proof(program_content_binary: Binary) -> (Vec<u8>, Ve
 }
 
 pub fn run_program_and_get_proof_internal(program_content: &[u8]) -> (Vec<u8>, Vec<u8>) {
-    let (main_trace, cairo_air, mut pub_inputs) =
-        generate_prover_args(program_content, &CairoVersion::V1, &None, GRINDING_FACTOR).unwrap();
+    // this is the default configuration for the proof generation
+    // TODO: this should be used only for testing.
+    let proof_options = ProofOptions::default_test_options();
 
-    let pub_inputs_serialized = pub_inputs.serialize();
+    let (main_trace, pub_inputs) =
+        generate_prover_args(program_content, &CairoVersion::V1, &None).unwrap();
 
-    let proof = prove(&main_trace, &cairo_air, &mut pub_inputs).unwrap();
-    let proof_serialized: Vec<u8> = proof.serialize();
-    (proof_serialized, pub_inputs_serialized)
+    let proof = generate_cairo_proof(&main_trace, &pub_inputs, &proof_options).unwrap();
+
+    let proof_bytes: Vec<u8> = proof.serialize();
+    let public_inputs_bytes = pub_inputs.serialize();
+    (proof_bytes, public_inputs_bytes)
 }
 
-pub fn verify_internal<F, A>(proof_bytes: &[u8], air: &A, public_inputs_bytes: &[u8]) -> bool
-where
-    F: IsFFTField,
-    A: AIR<Field = F>,
-    FieldElement<F>: ByteConversion,
-{
+pub fn verify_internal(proof_bytes: &[u8], public_inputs_bytes: &[u8]) -> bool {
     // At this point, the verifier only knows about the serialized proof, the proof options
     // and the public inputs.
     let proof = StarkProof::<Stark252PrimeField>::deserialize(&proof_bytes).unwrap();
-
-    // The same proof configuration as used in the `generate_prover_args` function.
-    let proof_options = ProofOptions {
-        blowup_factor: 4,
-        fri_number_of_queries: 3,
-        coset_offset: 3,
-        grinding_factor: 1,
-    };
-
+    let proof_options = ProofOptions::default_test_options();
     let public_inputs = PublicInputs::deserialize(public_inputs_bytes).unwrap();
 
-    let air = CairoAIR::new(proof_options, proof.trace_length, public_inputs, false);
-
-    //verify(&proof, &air, &public_inputs)
-
-    //assert!();
-
-    true
+    verify_cairo_proof(&proof, &public_inputs, &proof_options)
 }
 
 #[cfg(test)]
@@ -66,7 +47,10 @@ mod test {
     #[test]
     fn test_run_program_and_get_proof() {
         let program_content = std::fs::read("../../programs/fibonacci_cairo1.casm").unwrap();
-        let ret = super::run_program_and_get_proof_internal(&program_content);
-        println!("ret len: {}", ret.0.len());
+        let (proof_bytes, public_inputs_bytes) =
+            super::run_program_and_get_proof_internal(&program_content);
+        println!("proof_bytes len: {}", proof_bytes.len());
+
+        assert!(super::verify_internal(&proof_bytes, &public_inputs_bytes));
     }
 }


### PR DESCRIPTION
This PR updates the version of lambdaworks used that simplifies calling the prover and verifier for Cairo programs.