### PR TITLE
Fix felt input deserialization for RPC signatures

### DIFF
--- a/sequencer/consensus/src/tests/messages_tests.rs
+++ b/sequencer/consensus/src/tests/messages_tests.rs
@@ -49,7 +49,7 @@ fn verify_qc_insufficient_stake() {
 
     // Verify the QC.
     match qc.verify(&committee()) {
-        Err(ConsensusError::QCRequiresQuorum) => {},
+        Err(ConsensusError::QCRequiresQuorum) => {}
         _ => panic!(),
     }
 }

--- a/sequencer/rpc_endpoint/src/rpc/mod.rs
+++ b/sequencer/rpc_endpoint/src/rpc/mod.rs
@@ -10,6 +10,8 @@ use jsonrpsee::proc_macros::rpc;
 pub mod types;
 pub use types::*;
 
+use self::serializable_types::FeltParam;
+
 /// Starknet rpc interface.
 #[rpc(server, namespace = "starknet")]
 pub trait StarknetRpcApi {
@@ -130,7 +132,7 @@ pub trait StarknetRpcApi {
 
     /// Returns the information about a transaction by transaction hash.
     #[method(name = "getTransactionByHash")]
-    fn get_transaction_by_hash(&self, transaction_hash: Felt252) -> RpcResult<Transaction>;
+    fn get_transaction_by_hash(&self, transaction_hash: FeltParam) -> RpcResult<Transaction>;
 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]

--- a/sequencer/rpc_endpoint/src/rpc/mod.rs
+++ b/sequencer/rpc_endpoint/src/rpc/mod.rs
@@ -31,8 +31,8 @@ pub trait StarknetRpcApi {
     #[method(name = "getStorageAt")]
     fn get_storage_at(
         &self,
-        contract_address: Felt252,
-        key: Felt252,
+        contract_address: FeltParam,
+        key: FeltParam,
         block_id: BlockId,
     ) -> RpcResult<Felt252>;
 
@@ -45,13 +45,13 @@ pub trait StarknetRpcApi {
     fn get_class_at(
         &self,
         block_id: BlockId,
-        contract_address: Felt252,
+        contract_address: FeltParam,
     ) -> RpcResult<ContractClass>;
 
     /// Get the contract class hash in the given block for the contract deployed at the given
     /// address
     #[method(name = "getClassHashAt")]
-    fn get_class_hash_at(&self, block_id: BlockId, contract_address: Felt252)
+    fn get_class_hash_at(&self, block_id: BlockId, contract_address: FeltParam)
         -> RpcResult<Felt252>;
 
     /// Get an object about the sync status, or false if the node is not syncing
@@ -60,7 +60,7 @@ pub trait StarknetRpcApi {
 
     /// Get the contract class definition in the given block associated with the given hash
     #[method(name = "getClass")]
-    fn get_class(&self, block_id: BlockId, class_hash: Felt252) -> RpcResult<ContractClass>;
+    fn get_class(&self, block_id: BlockId, class_hash: FeltParam) -> RpcResult<ContractClass>;
 
     /// Get block information with transaction hashes given the block id
     #[method(name = "getBlockWithTxHashes")]
@@ -71,7 +71,7 @@ pub trait StarknetRpcApi {
 
     /// Get the nonce associated with the given address at the given block
     #[method(name = "getNonce")]
-    fn get_nonce(&self, block_id: BlockId, contract_address: Felt252) -> RpcResult<Felt252>;
+    fn get_nonce(&self, block_id: BlockId, contract_address: FeltParam) -> RpcResult<Felt252>;
 
     /// Get block information with full transactions given the block id
     #[method(name = "getBlockWithTxs")]
@@ -138,6 +138,6 @@ pub trait StarknetRpcApi {
     #[method(name = "getTransactionReceipt")]
     fn get_transaction_receipt(
         &self,
-        transaction_hash: Felt252,
+        transaction_hash: FeltParam,
     ) -> RpcResult<MaybePendingTransactionReceipt>;
 }

--- a/sequencer/rpc_endpoint/src/rpc/types/codegen.rs
+++ b/sequencer/rpc_endpoint/src/rpc/types/codegen.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 
 use cairo_felt::Felt252;
 
-use log::info;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 

--- a/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
+++ b/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
@@ -30,7 +30,7 @@ impl<'de> DeserializeAs<'de, Felt252> for FeltHex {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Ok(Felt252::from_bytes_be(value.as_bytes()))
+        Ok(Felt252::parse_bytes(value.as_bytes(), 16).unwrap())
     }
 }
 
@@ -130,6 +130,8 @@ pub mod base64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::rpc::{InvokeTransaction, InvokeTransactionV1, Transaction};
+
     use super::*;
 
     use serde_with::serde_as;
@@ -143,5 +145,28 @@ mod tests {
     fn empty_string_deser() {
         let r = serde_json::from_str::<TestStruct>("\"\"").unwrap();
         assert_eq!(r.0, None);
+    }
+
+    #[test]
+    fn serialize_deserialize_tx() {
+        let starknet_transaction =
+            Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
+                transaction_hash: Felt252::new(2314),
+                max_fee: Felt252::new(1),
+                signature: vec![Felt252::new(423)],
+                nonce: Felt252::new(1),
+                sender_address: Felt252::new(1),
+                calldata: vec![Felt252::new(2)],
+            }));
+
+        let starknet_transaction_str = serde_json::to_string(&starknet_transaction).unwrap();
+
+        let deserialized_tx: Transaction = serde_json::from_str(&starknet_transaction_str).unwrap();
+        if let Transaction::Invoke(InvokeTransaction::V1(v)) = deserialized_tx {
+            assert_eq!(Felt252::new(2314), v.transaction_hash);
+            assert_eq!(&Felt252::new(423), v.signature.first().unwrap());
+        } else {
+            panic!()
+        }
     }
 }

--- a/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
+++ b/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
@@ -1,7 +1,10 @@
 use cairo_felt::Felt252;
-use serde::{Deserialize, Deserializer, Serializer, Serialize};
-use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::{serde_as, DeserializeAs, SerializeAs};
 
+// We need the newtype in order to be able to use it the RPC function signatures since
+// jsonrpsee uses serde's deserialize implementations to deserialize params and
+// Felt252's from cairo-felt ends up deserializing from the limbs instead of a hex number
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct FeltParam(#[serde_as(as = "FeltHex")] pub Felt252);

--- a/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
+++ b/sequencer/rpc_endpoint/src/rpc/types/serializable_types.rs
@@ -1,6 +1,10 @@
 use cairo_felt::Felt252;
-use serde::{Deserialize, Deserializer, Serializer};
-use serde_with::{DeserializeAs, SerializeAs};
+use serde::{Deserialize, Deserializer, Serializer, Serialize};
+use serde_with::{DeserializeAs, SerializeAs, serde_as};
+
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct FeltParam(#[serde_as(as = "FeltHex")] pub Felt252);
 
 pub struct FeltHex;
 
@@ -26,7 +30,7 @@ impl<'de> DeserializeAs<'de, Felt252> for FeltHex {
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        Ok(Felt252::parse_bytes(value.as_bytes(), 16).unwrap())
+        Ok(Felt252::from_bytes_be(value.as_bytes()))
     }
 }
 
@@ -126,8 +130,6 @@ pub mod base64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::rpc::{InvokeTransaction, InvokeTransactionV1, Transaction};
-
     use super::*;
 
     use serde_with::serde_as;
@@ -141,28 +143,5 @@ mod tests {
     fn empty_string_deser() {
         let r = serde_json::from_str::<TestStruct>("\"\"").unwrap();
         assert_eq!(r.0, None);
-    }
-
-    #[test]
-    fn serialize_deserialize_tx() {
-        let starknet_transaction =
-            Transaction::Invoke(InvokeTransaction::V1(InvokeTransactionV1 {
-                transaction_hash: Felt252::new(2314),
-                max_fee: Felt252::new(1),
-                signature: vec![Felt252::new(423)],
-                nonce: Felt252::new(1),
-                sender_address: Felt252::new(1),
-                calldata: vec![Felt252::new(2)],
-            }));
-
-        let starknet_transaction_str = serde_json::to_string(&starknet_transaction).unwrap();
-
-        let deserialized_tx: Transaction = serde_json::from_str(&starknet_transaction_str).unwrap();
-        if let Transaction::Invoke(InvokeTransaction::V1(v)) = deserialized_tx {
-            assert_eq!(Felt252::new(2314), v.transaction_hash);
-            assert_eq!(&Felt252::new(423), v.signature.first().unwrap());
-        } else {
-            panic!()
-        }
     }
 }

--- a/sequencer/rpc_endpoint/src/starknet_backend.rs
+++ b/sequencer/rpc_endpoint/src/starknet_backend.rs
@@ -4,7 +4,7 @@ use crate::rpc::{
     ContractClass, DeclareTransactionResult, DeployAccountTransactionResult, EventFilterWithPage,
     EventsPage, FeeEstimate, FunctionCall, InvokeTransaction, InvokeTransactionResult,
     MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingTransactionReceipt,
-    StarknetRpcApiServer, StateUpdate, SyncStatusType, Transaction,
+    StarknetRpcApiServer, StateUpdate, SyncStatusType, Transaction, serializable_types::FeltParam,
 };
 use cairo_felt::Felt252;
 use jsonrpsee::{
@@ -220,7 +220,12 @@ impl StarknetRpcApiServer for StarknetBackend {
     /// # Arguments
     ///
     /// * `transaction_hash` - Transaction hash corresponding to the transaction.
-    fn get_transaction_by_hash(&self, transaction_hash: Felt252) -> RpcResult<Transaction> {
+    fn get_transaction_by_hash(&self, transaction_hash: FeltParam) -> RpcResult<Transaction> {
+        // necessary destructuring so that we can use a hex felt as a param
+        let transaction_hash = transaction_hash.0;
+
+        info!("{}", transaction_hash);
+        
         // TODO: add error handling
         let tx = &self
             .store

--- a/sequencer/rpc_endpoint/src/starknet_backend.rs
+++ b/sequencer/rpc_endpoint/src/starknet_backend.rs
@@ -224,8 +224,6 @@ impl StarknetRpcApiServer for StarknetBackend {
         // necessary destructuring so that we can use a hex felt as a param
         let transaction_hash = transaction_hash.0;
 
-        info!("{}", transaction_hash);
-
         // TODO: add error handling
         let tx = &self
             .store

--- a/sequencer/rpc_endpoint/src/starknet_backend.rs
+++ b/sequencer/rpc_endpoint/src/starknet_backend.rs
@@ -1,10 +1,10 @@
 use crate::rpc::{
-    BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
+    serializable_types::FeltParam, BlockHashAndNumber, BlockId, BroadcastedDeclareTransaction,
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ContractClass, DeclareTransactionResult, DeployAccountTransactionResult, EventFilterWithPage,
     EventsPage, FeeEstimate, FunctionCall, InvokeTransaction, InvokeTransactionResult,
     MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, MaybePendingTransactionReceipt,
-    StarknetRpcApiServer, StateUpdate, SyncStatusType, Transaction, serializable_types::FeltParam,
+    StarknetRpcApiServer, StateUpdate, SyncStatusType, Transaction,
 };
 use cairo_felt::Felt252;
 use jsonrpsee::{
@@ -225,7 +225,7 @@ impl StarknetRpcApiServer for StarknetBackend {
         let transaction_hash = transaction_hash.0;
 
         info!("{}", transaction_hash);
-        
+
         // TODO: add error handling
         let tx = &self
             .store

--- a/sequencer/rpc_endpoint/src/starknet_backend.rs
+++ b/sequencer/rpc_endpoint/src/starknet_backend.rs
@@ -116,7 +116,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     }
 
     /// Returns the chain id.
-    fn chain_id(&self) -> RpcResult<FeltParam> {
+    fn chain_id(&self) -> RpcResult<Felt252> {
         unimplemented!();
     }
 

--- a/sequencer/rpc_endpoint/src/starknet_backend.rs
+++ b/sequencer/rpc_endpoint/src/starknet_backend.rs
@@ -37,8 +37,8 @@ impl StarknetRpcApiServer for StarknetBackend {
     /// get the storage at a given address and key and at a given block
     fn get_storage_at(
         &self,
-        contract_address: Felt252,
-        key: Felt252,
+        contract_address: FeltParam,
+        key: FeltParam,
         block_id: BlockId,
     ) -> RpcResult<Felt252> {
         unimplemented!();
@@ -52,7 +52,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     fn get_class_at(
         &self,
         block_id: BlockId,
-        contract_address: Felt252,
+        contract_address: FeltParam,
     ) -> RpcResult<ContractClass> {
         unimplemented!();
     }
@@ -72,7 +72,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     fn get_class_hash_at(
         &self,
         block_id: BlockId,
-        contract_address: Felt252,
+        contract_address: FeltParam,
     ) -> RpcResult<Felt252> {
         unimplemented!();
     }
@@ -83,7 +83,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     }
 
     /// Get the contract class definition in the given block associated with the given hash.
-    fn get_class(&self, block_id: BlockId, class_hash: Felt252) -> RpcResult<ContractClass> {
+    fn get_class(&self, block_id: BlockId, class_hash: FeltParam) -> RpcResult<ContractClass> {
         unimplemented!();
     }
 
@@ -96,7 +96,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     }
 
     /// Get the nonce associated with the given address at the given block
-    fn get_nonce(&self, block_id: BlockId, contract_address: Felt252) -> RpcResult<Felt252> {
+    fn get_nonce(&self, block_id: BlockId, contract_address: FeltParam) -> RpcResult<Felt252> {
         unimplemented!();
     }
 
@@ -116,7 +116,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     }
 
     /// Returns the chain id.
-    fn chain_id(&self) -> RpcResult<Felt252> {
+    fn chain_id(&self) -> RpcResult<FeltParam> {
         unimplemented!();
     }
 
@@ -252,7 +252,7 @@ impl StarknetRpcApiServer for StarknetBackend {
     /// * `transaction_hash` - Transaction hash corresponding to the transaction.
     fn get_transaction_receipt(
         &self,
-        transaction_hash: Felt252,
+        transaction_hash: FeltParam,
     ) -> RpcResult<MaybePendingTransactionReceipt> {
         unimplemented!();
     }


### PR DESCRIPTION
- Adds a newtype needed for RPC function signatures since jsonrpsee tries to serialize/deserialize Felt252 which ends up looking something like this: `Felt252::new(1)` <-> `{"value":{"val":[1]}}`. See comment for more info
- Changes the signature for all RPC calls to use the newtype
- Clippy warning cleanup