### PR TITLE
Freeze Explorer commit for stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 clone-madara-explorer:
 	if [ ! -d "madara_explorer" ]; then \
-		git clone --recurse-submodules https://github.com/lambdaclass/madara_explorer.git --branch main && git submodule update; \
+		git clone --recurse-submodules https://github.com/lambdaclass/madara_explorer.git --branch main && git submodule update && cd madara_explorer && git checkout cf0857d3ff5ee2bfdd3ffdd57bb208f0b0260003; \
 	fi
 
 docker-build-sequencer:


### PR DESCRIPTION
Because the explorer will be implementing further RPC calls for showing more data, the integration with the Starknet Stack blockchain will likely be broken at some point. By freezing the explorer rev that we integrate, we can control this as we implement the required RPC calls ourselves.
Closes #97. 