### PR TITLE
Add transaction RPC calls

### DIFF
--- a/sequencer/Makefile
+++ b/sequencer/Makefile
@@ -11,7 +11,7 @@ N:=0
 node: 
 	export MLIR_SYS_160_PREFIX=/opt/homebrew/opt/llvm@16 && \
 	cd benchmark && \
-	RUST_LOG=info,salsa=off,cairo_native=off,sled=off cargo run --bin node --features benchmark -- -vvv run --keys ./.node-$(N).json --committee ./.committee.json --parameters ./.parameters.json --store ./.db-$(N)
+	RUST_LOG=INFO,salsa=off,cairo_native=off,sled=off,consensus=off cargo run --bin node --features benchmark -- -vvv run --keys ./.node-$(N).json --committee ./.committee.json --parameters ./.parameters.json --store ./.db-$(N)
 
 reset:
 	rm -rf ./benchmark/.db-*

--- a/sequencer/node/src/hotstuff_node.rs
+++ b/sequencer/node/src/hotstuff_node.rs
@@ -44,6 +44,7 @@ pub struct HotstuffNode {
     pub mempool_transaction_endpoint: SocketAddr,
     execution_program: ExecutionEngine,
     last_committed_round: u64,
+    pub transaction_endpoint: SocketAddr,
 }
 
 impl HotstuffNode {
@@ -122,6 +123,10 @@ impl HotstuffNode {
             mempool_transaction_endpoint: committee
                 .mempool
                 .mempool_address(&name)
+                .expect("Error retrieving our own mempool parameters while initializing"),
+            transaction_endpoint: committee
+                .mempool
+                .transactions_address(&name)
                 .expect("Error retrieving our own mempool parameters while initializing"),
             external_store,
             execution_program: execution_engine,

--- a/sequencer/node/src/main.rs
+++ b/sequencer/node/src/main.rs
@@ -103,7 +103,7 @@ async fn main() {
                     let rpc_port = node.mempool_transaction_endpoint.port() + RPC_PORT_OFFSET;
 
                     // Start RPC backend module
-                    StarknetBackend::spawn(external_store, rpc_port);
+                    StarknetBackend::spawn(external_store, rpc_port, node.transaction_endpoint);
 
                     tokio::spawn(async move {
                         node.analyze_block().await;
@@ -190,7 +190,7 @@ fn deploy_testbed(nodes: u16) -> Result<Vec<JoinHandle<()>>, Box<dyn std::error:
                         let rpc_port = node.mempool_transaction_endpoint.port() + RPC_PORT_OFFSET;
 
                         // Start RPC backend module
-                        StarknetBackend::spawn(external_store, rpc_port);
+                        StarknetBackend::spawn(external_store, rpc_port, node.transaction_endpoint);
                         // Sink the commit channel.
                         while node.commit.recv().await.is_some() {}
                     }

--- a/sequencer/rpc_endpoint/Cargo.toml
+++ b/sequencer/rpc_endpoint/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 bincode = "1.3.3"
 log = "0.4.0"
 jsonrpsee = { version="0.18.2", default-features = true, features = ["server", "macros"] }
+futures = "0.3.8"
 mempool = { path = "../mempool" }
 sequencer = { path = "../sequencer" }
 types = { path = "../types" }
@@ -20,6 +21,7 @@ serde_with = "3.0.0"
 thiserror = "1.0.46"
 base64 = "0.21.2"
 tokio = "1.28.2"
+tokio-util = { version = "0.7.3", features = ["codec"] }
 anyhow = "1.0.71"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
@@ -28,3 +30,4 @@ tracing-subscriber = { version = "0.3", features = [
     "std",
 ] }
 bytes = "1.0.1"
+starknet_in_rust = { git="https://github.com/lambdaclass/starknet_in_rust/", branch="add_cairo_native"}

--- a/sequencer/rpc_endpoint/src/lib.rs
+++ b/sequencer/rpc_endpoint/src/lib.rs
@@ -1,2 +1,5 @@
+
+
+
 pub mod rpc;
 pub mod starknet_backend;

--- a/sequencer/types/src/codegen.rs
+++ b/sequencer/types/src/codegen.rs
@@ -624,7 +624,7 @@ pub struct InvokeTransactionV1 {
 // TODO move this code to the uppermost Transaction enum and adapt for different
 // transaction types.
 impl InvokeTransactionV1 {
-    fn calculate_hash(&self) -> u64 {
+    pub fn calculate_hash(&self) -> u64 {
         let mut s = DefaultHasher::new();
         self.hash(&mut s);
         s.finish()


### PR DESCRIPTION
Allow calls via the RPC standard:

```
curl -H "Content-Type: application/json" http://localhost:10011 -d '{"jsonrpc": "2.0","method": "starknet_addInvokeTransaction","params": [
    {
      "contract_address": "0x1",
      "sender_address": "0x1",
      "version": "0x1",
      "max_fee": "0x1",
      "signature": [
        "0x23"
      ],
      "nonce": "2",
      "type": "INVOKE",
      "calldata": [
        "0x0","0x112e35f48499939272000bd72eb840e502ca4c3aefa8800992e8defb746e0c9"
        ,"0x10",
        "0x1",
        "0xA"
      ]}],"id": 1}'


{"jsonrpc":"2.0","result":{"transaction_hash":"0x3422c6cbcfaeaabd"},"
```